### PR TITLE
Small Clean Up

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Awesome List for Phoenix.  Compiles a list of awesome references from the az-web
 * Dev Mountain - [https://devmountain.com/phoenix-bootcamp](https://devmountain.com/phoenix-bootcamp)
 * Galvanize Phoenix - [https://www.galvanize.com/phoenix/full-time](https://www.galvanize.com/phoenix/full-time)
 * Interface Technical Training (Windows/Ops focus) - [https://www.interfacett.com/](https://www.interfacett.com/)
+* University of Arizona Coding Boot Camp - [https://codingbootcamp.ce.arizona.edu/](https://codingbootcamp.ce.arizona.edu/)
 
 ## Dev Shops In Phoenix
 * AKOS - [https://akosweb.com/](https://akosweb.com/)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ Awesome List for Phoenix.  Compiles a list of awesome references from the az-web
 * Deskhub - [http://www.deskhub.com/scottsdale/](http://www.deskhub.com/scottsdale/)
 * FABRIC - [https://www.fabrictempe.com/](https://www.fabrictempe.com/)
 * Galvanize Phoenix - [https://www.galvanize.com/phoenix/campus](https://www.galvanize.com/phoenix/campus)
-* Gangplank - [http://gangplankhq.com/](http://gangplankhq.com/)
+* Gangplank Avondale - [https://gangplankhq.com/avondale/](https://gangplankhq.com/avondale/)
+* Gangplank Chandler - [https://gangplankhq.com/chandler/](https://gangplankhq.com/chandler/)
+* Gangplank Queen Creek - [https://gangplankhq.com/queen-creek/](https://gangplankhq.com/queen-creek/)
 * MAC6 Conscious Spaces - [https://mac6.com/conscious-workspace/](https://mac6.com/conscious-workspace/)
 * monOrchid - [http://www.monorchid.com/](http://www.monorchid.com/)
 * The Newton - [http://www.thenewtonphx.com/](http://www.thenewtonphx.com/)
@@ -61,6 +63,7 @@ Awesome List for Phoenix.  Compiles a list of awesome references from the az-web
 * Sozo Coffee - [http://sozocoffee.org/index.html](http://sozocoffee.org/index.html)
 
 ## Hackerspaces And Makerspaces
+* Gangplank Queen Creek - [https://gangplankhq.com/queen-creek/](https://gangplankhq.com/queen-creek/)
 * Heatsync Labs - [https://heatsynclabs.org](https://heatsynclabs.org)
 * Tech Shop
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Awesome List for Phoenix.  Compiles a list of awesome references from the az-webdevs channel.
 
 * [Resources for Organization](#resources-for-organization)
-* [Co-working Spaces](#co-working-spaces)
+* [Coworking Spaces](#coworking-spaces)
 * [Job Boards And Recruiting](#job-boards-and-recruiting)
 * [Dev-Friendly Space](#dev-friendly-spaces)
 * [Hackerspaces and Makerspaces](#hackerspaces-and-makerspaces)
@@ -20,7 +20,7 @@ Awesome List for Phoenix.  Compiles a list of awesome references from the az-web
 * phxtech.rocks - [http://phxtech.rocks/](http://phxtech.rocks/)
 * #yesphx - [http://yesphx.com/](http://yesphx.com/)
 
-## Co-Working Spaces
+## Coworking Spaces
 * BRIC - [http://www.tempe.gov/city-hall/economic-development/entrepreneurs/bric](http://www.tempe.gov/city-hall/economic-development/entrepreneurs/bric)
 * CO+HOOTS - [https://cohoots.com/](https://cohoots.com/)
 * The Croft Downtown - [https://www.thecroftdowntown.com/](https://www.thecroftdowntown.com/)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Awesome List for Phoenix.  Compiles a list of awesome references from the az-web
 ## Hackerspaces And Makerspaces
 * Gangplank Queen Creek - [https://gangplankhq.com/queen-creek/](https://gangplankhq.com/queen-creek/)
 * Heatsync Labs - [https://heatsynclabs.org](https://heatsynclabs.org)
-* Tech Shop
+* Tech Shop - [http://www.techshop.ws/ts_chandler.html](http://www.techshop.ws/ts_chandler.html)
 
 ## Code Academies
 * Dev Mountain - [https://devmountain.com/phoenix-bootcamp](https://devmountain.com/phoenix-bootcamp)

--- a/README.md
+++ b/README.md
@@ -114,5 +114,6 @@ Awesome List for Phoenix.  Compiles a list of awesome references from the az-web
 * RevolutionParts - [http://www.revolutionparts.com/](http://www.revolutionparts.com/)
 * RetailMeNot - [https://www.retailmenot.com/](https://www.retailmenot.com/)
 * Shutterfly
+* Tanga - [http://www.tanga.com/](http://www.tanga.com)
 * Tuft & Needle - [https://www.tuftandneedle.com/](https://www.tuftandneedle.com/)
 * Virtuous - [http://www.virtuouscrm.com/](http://www.virtuouscrm.com/)


### PR DESCRIPTION
- removed hyphenation from co-working.
- split Gangplank into 3 locations with updated urls
- added Gangplank Queen Creek to maker space section
- updated techshop URL
- added tanga to list of companies with developers
- added UofA bootcamp